### PR TITLE
Use macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ For applications that need to perform common I/O operations, the Language Enviro
 
 ### I/O Macros
 
-- [DCBD](https://www.ibm.com/docs/en/zos/3.1.0?topic=nvmd-dcbdprovide-symbolic-reference-data-control-blocks-bdam-bisam-bpam-bsam-qisam-qsam) [Macro](): Data Control Block symbolic names.
-- [DCB BPAM]() [Macro](https://tech.mikefulton.ca/DCBBPAMMacro): DCB Macro for BPAM usage
+- [DCBD Macro](https://www.ibm.com/docs/en/zos/3.1.0?topic=nvmd-dcbdprovide-symbolic-reference-data-control-blocks-bdam-bisam-bpam-bsam-qisam-qsam): Data Control Block symbolic names.
+- [DCB BPAM Macro](https://tech.mikefulton.ca/DCBBPAMMacro): DCB Macro for BPAM usage
+- [Dynalloc Macro](https://tech.mikefulton.ca/DynallocMacro): Dynamic Allocation of DCB
 - [OPEN](https://www.ibm.com/docs/en/zos/3.1.0?topic=nvmd-openconnect-program-data-bdam-bisam-interface-vsam-bpam-bsam-qisam-interface-vsam-qsam) [Macro](https://tech.mikefulton.ca/QSAMOPEN), 
   - [Macro](https://tech.mikefulton.ca/DynallocMacro): DYNALLOC aka SVC99 
 - [BLDL](https://www.ibm.com/docs/en/zos/3.1.0?topic=pdse-using-bldl-macro-construct-directory-entry-list) Macro: Read one or more directory entries into virtual storage.

--- a/asmxmp/macmem.s
+++ b/asmxmp/macmem.s
@@ -51,6 +51,7 @@ STG_WA_CLEAR DS 0H
 
 STG_DCB_CLEAR DS 0H
 
+         OPEN MODE=31,MF=(E,(7))
 *
 * Body of Code
 *

--- a/src/dioa.s
+++ b/src/dioa.s
@@ -379,8 +379,8 @@ S99A     ASDPRO BASE_REG=3,USR_DSAL=S99A_DSAL
          L   R2,S99ARBP
          OILH R2,X'8000'
          ST  R2,0(,R1)
-* Call SVC99 (DYNALLOC) with S99RBP
-         SVC 99
+* Call DYNALLOC (SVC99) with S99RBP
+         DYNALLOC 
 *
 S99A_EXIT   DS    0H
          ASDEPI
@@ -410,12 +410,14 @@ STOWA    ASDPRO BASE_REG=3,USR_DSAL=STOWA_DSAL
 *  R15 is also the list address
 
          USING STOWA_PARMS,R1
+
          L   R3,STOWA_LST
          L   R4,STOWA_DCB
          L   R0,0(,R3)
          L   R1,0(,R4)
-         LR  R15,R0
-         SVC 21
+         LR  R15,R0          # R15 also needs to be set
+         STOW (1),(0)
+
 *
 * For the return, put low halfword of R0 
 * into high halfword of R15 and return R15

--- a/src/dioa.s
+++ b/src/dioa.s
@@ -87,15 +87,12 @@ FINDA    ASDPRO BASE_REG=3,USR_DSAL=FINDA_DSAL
 * Call SVC18 with R0 pointing to PLIST and R1 (complement) 
 * containing DCB address
 *
-* The FIND macro is not used - it generates 'fluff' tests that
-* are unnecessary and so a direct call to the SVC is used
-
-*        FIND FINDA_DCB,FINDA_PLIST,D
+* The FIND macro generates 'fluff' tests that
+* are unnecessary, but it is cleaner than calling SVC 18 directly
 
          L   R0,FINDA_PLIST
          L   R1,FINDA_DCB
-         LCR R1,R1
-         SVC 18
+         FIND (1),(0),D
 
          SLL R0,16
          OR  R15,R0

--- a/src/dioa.s
+++ b/src/dioa.s
@@ -174,21 +174,18 @@ WRITEA_DSAL    EQU 0
 DIOA     CSECT
          ENTRY CHECKA
 CHECKA   ASDPRO BASE_REG=3,USR_DSAL=CHECKA_DSAL
-         LR    R7,R1
-         USING CHECKA_PARMS,R7
 
 *
 * Set R2 to 0 indicating 'not end of data'
+* EODAD exit may be called as side effect of CHECK
 *
          SR  R2,R2
 
 * Call CHECK function 
+
+         USING CHECKA_PARMS,R1
          L   R1,CHECKA_DECB
-         USING DECB,R1
-         L   R15,DECDCBAD
-         USING IHADCB,R15
-         ICM R15,B'0111',DCBCHCKA
-         BALR R14,R15
+         CHECK (1)
 
 *
 * Copy 'end of data' indicator into R15
@@ -215,16 +212,13 @@ CHECKA_DSAL    EQU 0
 DIOA     CSECT
          ENTRY NOTEA
 NOTEA    ASDPRO BASE_REG=3,USR_DSAL=NOTEA_DSAL
-         LR    R7,R1
-         USING NOTEA_PARMS,R7
 
-* Call NOTE function (found in DCB)
+* Call NOTE function 
+
+         USING NOTEA_PARMS,R1
          L   R1,NOTEA_DCB
-         XR  R15,R15
-         USING IHADCB,R1
-         ICM R15,B'0111',DCBNOTE+1
-         BASR R14,R15
-         LR  R15,R1
+         NOTE (1)
+
 *
 NOTEA_EXIT   DS    0H
          ASDEPI

--- a/src/dioa.s
+++ b/src/dioa.s
@@ -75,11 +75,17 @@ FINDA    ASDPRO BASE_REG=3,USR_DSAL=FINDA_DSAL
 
 * Call SVC18 with R0 pointing to PLIST and R1 (complement) 
 * containing DCB address
+*
+* The FIND macro is not used - it generates 'fluff' tests that
+* are unnecessary and so a direct call to the SVC is used
+
+*        FIND FINDA_DCB,FINDA_PLIST,D
 
          L   R0,FINDA_PLIST
          L   R1,FINDA_DCB
          LCR R1,R1
          SVC 18
+
          SLL R0,16
          OR  R15,R0
 *
@@ -104,18 +110,15 @@ FINDA_DSAL    EQU 0
 DIOA     CSECT
          ENTRY READA
 READA    ASDPRO BASE_REG=3,USR_DSAL=READA_DSAL
-         LR    R7,R1
-         USING READA_PARMS,R7
 
-* Call Read function, found in DCB
-         L   R1,READA_DECB
-         USING DECB,R1
-         L   R15,DECDCBAD
-         USING IHADCB,R15
-         ICM R15,B'0111',DCBREADA
-         BALR R14,R15
+* Call Read function
+
+         USING READA_PARMS,R1
+         L    R1,READA_DECB
+         READ (1),SF,MF=E
+
 *
-* Does not seem to be a return code for READ?
+* No return code for READ. Use CHECK
 *
          LA  R15,0
 *
@@ -139,18 +142,15 @@ READA_DSAL    EQU 0
 DIOA     CSECT
          ENTRY WRITEA
 WRITEA   ASDPRO BASE_REG=3,USR_DSAL=WRITEA_DSAL
-         LR    R7,R1
-         USING WRITEA_PARMS,R7
 
-* Call Write function (found in DCB, which is 8(DECB))
-         L   R1,WRITEA_DECB
-         USING DECB,R1
-         L   R15,DECDCBAD
-         USING IHADCB,R15
-         ICM R15,B'0111',DCBWRITA
-         BALR R14,R15
+* Call Write Function
+
+         USING WRITEA_PARMS,R1
+         L    R1,WRITEA_DECB
+         WRITE (1),SF,MF=E
+
 *
-* Does not seem to be a return code for WRITE?
+* No return code for WRITE. Use CHECK
 *
          LA  R15,0
 *

--- a/src/dioa.s
+++ b/src/dioa.s
@@ -30,13 +30,9 @@ OPENA    ASDPRO BASE_REG=3,USR_DSAL=OPENA_DSAL
          USING DCBE,R8
          ST  R5,DCBEEODA
 
-* Call SVC19 (OPEN) with 24-bit DCB
+* Call SVC19 (OPEN) with 24-bit DCB in 31-bit MODE
+         OPEN MODE=31,MF=(E,(7))
 
-         LR  R0,R7
-         SR  R1,R1
-         SR  R15,R15
-         SVC 19
-*
 OPENA_EXIT   DS    0H
          ASDEPI
 


### PR DESCRIPTION
Code has been converted to use the macro form instead of going directly at the generated assembler. 