### PR TITLE
Eliminate some sharp edges

### DIFF
--- a/data/odd+name.txt
+++ b/data/odd+name.txt
@@ -1,0 +1,1 @@
+This is text

--- a/include/deserv.h
+++ b/include/deserv.h
@@ -153,7 +153,7 @@ struct desl {
     struct {
       unsigned char  _filler3[8];
       void * __ptr32 desl_new_name_ptr; /* pointer to new name,       @L2A */
-      void * __ptr32 desl_name_ptr;     /* pointer to name (DESN)          */
+      struct desl_name* __ptr32 desl_name_ptr; /* pointer to name (DESN)     */
       };
     struct {
       unsigned char  _filler4[12];

--- a/include/stow.h
+++ b/include/stow.h
@@ -25,13 +25,14 @@ struct stowlist_generic_includes_dcb {
   /* more stuff */
 };
 
+#define STOWLIST_IFF_TIMESTAMP_LEN (8)
 struct stowlist_iff {
   unsigned short list_len;
   unsigned char type;
   unsigned char reserved;
   int dcbHOB: 8;
   int dcb24: 24;
-  char timestamp[8];
+  char timestamp[STOWLIST_IFF_TIMESTAMP_LEN];
   void* __ptr32 direntry;
   char user_descriptor[16];
   unsigned short ccsid;
@@ -59,8 +60,8 @@ enum stowtype {
 enum stowcc {
   STOW_CC_OK=0,
   STOW_IFF_CC_CREATE_OK=4,
-  STOW_IFF_CC_UPDATE_FAILED=8,
-  STOW_IFF_CC_PDS_UPDATE_UNSUPPORTED=28
+  STOW_IFF_CC_MEMBER_EXISTS=8,
+  STOW_IFF_CC_PDS_UPDATE_UNSUPPORTED=0x40028
 };
 #pragma pack(pop)
 

--- a/sample/bpamio.h
+++ b/sample/bpamio.h
@@ -4,7 +4,7 @@
   #include "fm.h"
   #include "fmopts.h"
   int write_block(FM_BPAMHandle* bh, const FM_Opts* opts);
-  int write_member_dir_entry(const FM_BPAMHandle* bh, const FM_FileHandle* fh, const char* filename, const char* member, const FM_Opts* opts);
+  int write_member_dir_entry(const FM_BPAMHandle* bh, const FM_FileHandle* fh, const char* ds, const char* member, const FM_Opts* opts);
   int open_pds_for_write(const char* dataset, FM_BPAMHandle* bh, const FM_Opts* opts);
   int close_pds(const char* dataset, const FM_BPAMHandle* bh, const FM_Opts* opts);
 #endif

--- a/src/dioa.s
+++ b/src/dioa.s
@@ -29,7 +29,7 @@ OPENA    ASDPRO BASE_REG=3,USR_DSAL=OPENA_DSAL
          L   R7,OPENA_PARMSA
 
 *
-* Set up EODAD routine, which will just set R2 to non-zero
+* Set up EODAD routine, which will just set R2 to 1
 * R2 will be checked in the CHECKA code where it is 
 * expected to be triggered
 *
@@ -40,6 +40,15 @@ OPENA    ASDPRO BASE_REG=3,USR_DSAL=OPENA_DSAL
          L   R8,DCBDCBE
          USING DCBE,R8
          ST  R5,DCBEEODA
+
+* Set up SYNAD routine, which will just set R2 to 2
+         LA  R5,SYNAD
+         USING OPENA_PARMS,R7
+         L   R6,OPENA_DCB
+         USING IHADCB,R6
+         L   R8,DCBDCBE
+         USING DCBE,R8
+         ST  R5,DCBESYNA
 
 * Call OPEN with 24-bit DCB in 31-bit MODE
          OPEN MODE=31,MF=(E,(7))
@@ -53,6 +62,14 @@ EODAD    DS 0H
 * and then return to caller (CHECKA or READA via SVC19)
 *
          LA R2,1
+         BR R14
+
+SYNAD    DS 0H
+*
+* Set R2 to 2 indicating 'synchronous error'
+* and then return to caller (CHECKA or READA via SVC19)
+*
+         LA R2,2
          BR R14
 
          DROP

--- a/src/s99.c
+++ b/src/s99.c
@@ -168,9 +168,12 @@ int s99_prt_msg(FILE* stream, struct s99rb* __ptr32 svc99parms, int svc99rc)
 	msgparms->emwtpcdp = &msgparms->emwtdert;
 	msgparms->embufp = &msgparms->embuf;
 
+#if 0
 	fprintf(stream, "SVC99 parms:%p rc:0x%x\n", svc99parms, svc99rc);
 	fprintf(stream, "SVC99 failed with error:%d (0x%x) info: %d (0x%x)\n", 
 		svc99parms->s99error, svc99parms->s99error, svc99parms->s99info, svc99parms->s99info);
+#endif
+
 	rc = S99MSG(msgparms);
 	if (rc) {
 		fprintf(stream, "SVC99MSG rc:0x%x\n", rc);

--- a/test/f2mtest
+++ b/test/f2mtest
@@ -19,3 +19,9 @@ dtouch -l 137 -r vba "${hlq}.${mlq}.lst"
 
 time sample/f2m src "${hlq}.${mlq}" '*.*'
 time sample/f2m include "${hlq}.${mlq}" '*.*'
+
+#
+# run again with all members already existing
+#
+time sample/f2m src "${hlq}.${mlq}" '*.*'
+time sample/f2m include "${hlq}.${mlq}" '*.*'


### PR DESCRIPTION
- now supports adding a member when the member already exists
- produces reasonable messages if a sequential dataset or pds (vs PDSE) is specified
- prints out a message if a particular member was truncated on copy