### PR TITLE
Fix: Reset line_num in find_member() to prevent stale block reads

### DIFF
--- a/services/src/bpamio.c
+++ b/services/src/bpamio.c
@@ -607,7 +607,7 @@ int find_member(FM_BPAMHandle* bh, const char* mem, const DBG_Opts* opts)
    */
   bh->next_record_len = 0;
   bh->next_record_start = NULL;
-
+  bh->line_num = 0;
   return 0;
 }
 


### PR DESCRIPTION
# Pull Request Description

## 🐛 Bug Fix: PDS/PDSE Member Content Mismatch in Sequential Reads

### Problem Description

When copying multiple members from a PDS/PDSE dataset to USS files, the content was being shifted by one member position:
- Member B file contained Member A's content
- Member C file contained Member B's content
- And so on...

### Root Cause Analysis

The bug occurs in the interaction between `find_member()` and `read_record_direct()`:

**`read_record_direct()` Logic:**
```c
if ((bh->line_num == 0) || !next_record(bh, opts)) {
    // Read a fresh block
    read_block(bh, opts);
    next_record(bh, opts);
    bh->line_num++;
}
```

The condition `(bh->line_num == 0)` serves as a "fresh start" indicator. When TRUE, it forces reading a new block from the dataset.

**The Bug:**
`find_member()` uses the FIND macro to position to a new member but was **not resetting `bh->line_num` to 0**. This caused:

1. After reading Member A, `line_num` = 1
2. `find_member()` positions to Member B (but `line_num` stays 1)
3. `read_record_direct()` sees `line_num != 0` and tries to continue from the current block
4. It reads stale data from Member A's block instead of Member B's data

### The Fix

**File:** `services/src/bpamio.c`  
**Location:** Lines 608-611 in `find_member()` function

```c
/*
 * Clear the next record code so that we can know to read a block at the start of next_record
 */
bh->next_record_len = 0;
bh->next_record_start = NULL;
bh->line_num = 0;  // ← Added this line
return 0;
```

By resetting `line_num = 0`, we ensure that the next call to `read_record_direct()` will:
1. Recognize this is a fresh member read
2. Load a new block from the dataset
3. Return the correct content for the new member

### Test Evidence

**Before Fix:**
```
Member A: "Member A content" ✅
Member B: "Member A content" ❌ (should be "Member B content")
Member C: "Member B content" ❌ (should be "Member C content")
```

**After Fix:**
```
Member A: "Member A content" ✅
Member B: "Member B content" ✅
Member C: "Member C content" ✅
```

### Impact

- ✅ Fixes `test_pds_to_uss.sh` test failures
- ✅ Ensures correct content mapping for all PDS/PDSE to USS copy operations
- ✅ No performance impact (just a single integer assignment)
- ✅ No breaking changes to API or behavior

### Related Code

This fix complements the existing reset logic in `find_member()`:
- `bh->next_record_len = 0` - Clears record length
- `bh->next_record_start = NULL` - Clears record pointer
- `bh->line_num = 0` - **NEW:** Clears line counter to force fresh block read

All three resets are necessary to properly initialize the handle for reading a new member.